### PR TITLE
Rename namespace, remove --package option, add dependency metadata

### DIFF
--- a/src/cljsjs/impl/jars.clj
+++ b/src/cljsjs/impl/jars.clj
@@ -35,8 +35,7 @@
   [env markers exts]
   (letfn [(files [marker] (->> marker
                                (dep-jars-on-cp env)
-                               ; FIXME this breaks stuff currently
-                               ;(in-dep-order env)
+                               (in-dep-order env) ; FIXME this breaks stuff currently
                                (mapcat #(files-in-jar % marker exts))
                                (map first)))]
     (apply concat (map files markers))))


### PR DESCRIPTION
- Renamed cljsjs.app namespace to cljsjs.boot-cljsjs for consistency
  with other tasks.

- Use the boot.class.path system property instead of java.class.path to
  detect changed dependency JARs --- the latter will never change while
  boot is running, but the former will.

- Restored dependency ordering of jars (this is essential for correct
  treatment of unpacked files by other tasks).

- Merge cljsjs file dependency order info into the :dependency-order key
  of the filesystem metadata. Dependency order info is a map of path to
  integer. When paths are sorted by vals, paths at the end of the list
  depend on paths at the front.

- Removed the --package option: always use add-source. Other tasks can
  decide how to handle the unpacked files.