### PR TITLE
Saving angels

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ NOTE: This a bad example because React is added to fileset twice.
 
                           [cljsjs/boot-cljsjs "0.3.0-SNAPSHOT"]])
 
-(require '[cljsjs.app :refer :all])
+(require '[cljsjs.boot-cljsjs :refer [from-cljsjs from-jars from-webjars])
 
 (deftask dev []
   (comp


### PR DESCRIPTION
Every time anyone of us writes `:refer :all` in a namespace declaration, an angel falls from the sky and dies in agony. Let's be compassionate, OK?