### PR TITLE
Strip the cljsjs/{development,production,common,etc} dirs when dumping i...

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,6 +1,6 @@
 (set-env!
   :source-paths #{"src"}
-  :dependencies '[[adzerk/bootlaces "0.1.8" :scope "test"]])
+  :dependencies '[[adzerk/bootlaces "0.1.9" :scope "test"]])
 
 (require '[adzerk.bootlaces :refer :all])
 
@@ -15,5 +15,4 @@
                       libraries for Clojurescript projects"
         :url         "https://github.com/cljsjs/boot-cljsjs"
         :scm         {:url "https://github.com/cljsjs/boot-cljsjs"}
-        :license     {:name "Eclipse Public License"
-                      :url  "http://www.eclipse.org/legal/epl-v10.html"}})
+        :license     {"Eclipse Public License" "http://www.eclipse.org/legal/epl-v10.html"}})

--- a/src/cljsjs/boot_cljsjs.clj
+++ b/src/cljsjs/boot_cljsjs.clj
@@ -34,12 +34,13 @@
         (let [env       (c/get-env)
               markers   ["cljsjs/common/" (str "cljsjs/" (name profile) "/")]
               files     (jars/cljs-dep-files env markers [])
+              paths     (map #(.replaceAll % "^cljsjs/[^/]+/" "") files)
               dep-order (-> (fn [xs [n p]]
                               (assoc xs p {:dependency-order n}))
-                            (reduce {} (map-indexed list files)))]
+                            (reduce {} (map-indexed list paths)))]
           ;(prn :deps dep-order)
-          (doseq [f files]
-            (copy-file tmp f f))
+          (doseq [[f p] (map list files paths)]
+            (copy-file tmp f p))
           (reset! filemeta dep-order)))
       (-> fileset (c/add-source tmp) (c/add-meta @filemeta) c/commit!))))
 


### PR DESCRIPTION
...nto fileset

- Some tools get confused (google closure compiler, for example) when
  there is a file in a jar and in a directory on the class path with the
  same resource path. This commit addresses that issue.

- Also, when we use other resources like images etc, it's important that
  their paths relative to the HTML file are preserved, because css or js
  might reference them. Tools like the boot cljs task will install
  relevant files from cljsjs in the correct place, so we don't need to
  make special modifications to the css or js in most cases (only when
  they rely on absolute paths, which is terrible practice, anyway).