### PR TITLE
Create parent folders when saving files in download task

### DIFF
--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -63,6 +63,7 @@
     (cond->
       (c/with-pre-wrap fileset
         (let [target (io/file tmp fname)]
+          (io/make-parents target)
           (util/info "Downloading %s\n" fname)
           (with-open [is (:body (http/get url {:as :stream}))]
             (io/copy is target)))


### PR DESCRIPTION
When pulling down individual assets with the download task, it seems roundabout to match the files with sift after the download. I would prefer to just include the final path in the :name field. This causes problems when you specify a path that is not yet created.

Ensuring the parent paths are created allows for using paths in the name of the download task