### PR TITLE
Update clj-http version

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -1,7 +1,7 @@
 (set-env!
   :resource-paths #{"src"}
   :dependencies '[[org.apache.commons/commons-compress "1.9" :scope "test"]
-                  [clj-http "2.2.0" :scope "test"]
+                  [clj-http "3.4.1" :scope "test"]
                   [asset-minifier "0.1.7" :scope "test"]])
 
 (def +version+ "0.6.0")


### PR DESCRIPTION
In order to download from https://registry.npmjs.org, you need the latest version of clj-http. 

Example:

```
$ boot download -u https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.4.2.tgz
Downloading react-addons-transition-group-15.4.2.tgz
javax.net.ssl.SSLException: Certificate for <registry.npmjs.org> doesn't match any of the subject alternative names: [a.sni.fastly.net, a.sni.global-ssl.fastly.net]
clojure.lang.ExceptionInfo: Certificate for <registry.npmjs.org> doesn't match any of the subject alternative names: [a.sni.fastly.net, a.sni.global-ssl.fastly.net]
```

That error is caused from the clj-http `get` call:

```
(http/get "https://registry.npmjs.org/react-addons-transition-group/-/react-addons-transition-group-15.4.2.tgz" {:as :stream})
javax.net.ssl.SSLException: Certificate for <registry.npmjs.org> doesn't match any of the subject alternative names: [a.sni.fastly.net, a.sni.global-ssl.fastly.net]
```

And updating the latest clj-http fixes this issue.

It may also be worth considering updating asset-minifier to the latest version as well. 