### PR TITLE
Update regular expression for checksums to match package structure

### DIFF
--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -208,7 +208,7 @@
             (c/add-resource tmp)
             c/commit!)))))
 
-(def checksum-re #"^cljsjs/(.*/)?(common|production|dev)/.*\.inc\.js$")
+(def checksum-re #"^cljsjs/.*/(common|production|development)/.*\.(ext|inc)\.js$")
 
 (comment
   (re-matches checksum-re "cljsjs/foo/common/foo.inc.js")
@@ -224,7 +224,7 @@
   asks the user to validate changes, or in CI, throw error.
   New checksum are written to the file.
 
-  Default pattern to check is \"^cljsjs/.*/(common|production|dev)/.*.js$\".
+  Default pattern to check is \"^cljsjs/.*/(common|production|development)/.*\\.(ext|inc)\\.js$\".
 
   The checksum file should be commited to git."
   [_ patterns PATTERN [regex] "File patterns to check the checksums for"]


### PR DESCRIPTION
Without this fix of the regex, the `validate-checksums` function will only update the resources in the `boot-cljsjs-checksums.edn` file which are matched by the incomplete regex. This leads to deletion of entries in `boot-cljsjs-checksums.edn`.

The regex that describes which files have checksums now reflects:

- The cljsjs package structure uses `development` as directory name for dev resources ([documented here][1]).
- Resources that are checked do not only have an `.inc.js` file ending, the `.ext.js` resources are checked, too ([see here][2] or [here][3], for example).

[1]: https://github.com/cljsjs/packages/wiki/Creating-Packages#6-writing-the-package-task
[2]: https://github.com/cljsjs/packages/blob/4358108af31090b1dd5d4d9f3498689492771657/create-react-class/boot-cljsjs-checksums.edn
[3]: https://github.com/cljsjs/packages/blob/4358108af31090b1dd5d4d9f3498689492771657/parinfer-codemirror/boot-cljsjs-checksums.edn

Also, the regex that is displayed in the help message of `validate-checksums` is now indentical to the one actually used.