### PR TITLE
Update asset-minifier to allow es6 minification #53

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -5,7 +5,7 @@
                   [org.clojure/clojurescript "1.9.946" :scope "test"]
                   [cljsjs/react-dom "16.1.0-0" :scope "test"]
                   ;; Conflicts with cljs
-                  #_[asset-minifier "0.2.4" :scope "test" :exclusions []]])
+                  #_[asset-minifier "0.2.6" :scope "test" :exclusions []]])
 
 (def +version+ "0.10.1")
 

--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -236,7 +236,8 @@
    NOTE: potentially slow when called with watch or multiple times"
   [i in  INPUT  str "Path to file to be compressed"
    o out OUTPUT str "Path to where compressed file should be saved"
-   l lang LANGUAGE_IN kw "Language of the input javascript file. Default value is ecmascript6 in and ecmascript5 out."]
+   _ lang-in LANGUAGE_IN kw "Language of the input javascript file. Default value is ecmascript6"
+   _ lang-out LANGUAGE_OUT kw "Language of the input javascript file. Default value is ecmascript5"]
   (assert in "Path to input file required")
   (assert out "Path to output file required")
   (let [tmp      (c/tmp-dir!)
@@ -254,8 +255,8 @@
           (pod/with-eval-in min-pod
             (require 'asset-minifier.core)
             (asset-minifier.core/minify-js ~in-path ~out-path (if ~lang
-                                                                {:language-in ~lang
-                                                                 :language-out ~lang}
+                                                                {:language-in ~lang-in
+                                                                 :language-out (or ~lang-out ~lang-in)}
                                                                 {})))
           (. in-path (endsWith "css"))
           (pod/with-eval-in min-pod

--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -236,8 +236,8 @@
    NOTE: potentially slow when called with watch or multiple times"
   [i in  INPUT  str "Path to file to be compressed"
    o out OUTPUT str "Path to where compressed file should be saved"
-   _ lang-in LANGUAGE_IN kw "Language of the input javascript file. Default value is ecmascript6"
-   _ lang-out LANGUAGE_OUT kw "Language of the input javascript file. Default value is ecmascript5"]
+   l lang-in LANGUAGE_IN kw "Language of the input javascript file. Default value is ecmascript6"
+   L lang-out LANGUAGE_OUT kw "Language of the input javascript file. Default value is ecmascript5"]
   (assert in "Path to input file required")
   (assert out "Path to output file required")
   (let [tmp      (c/tmp-dir!)

--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -225,7 +225,7 @@
             c/commit!)))))
 
 (defn minifier-pod []
-  (pod/make-pod (assoc-in (c/get-env) [:dependencies] '[[asset-minifier "0.2.4"]])))
+  (pod/make-pod (assoc-in (c/get-env) [:dependencies] '[[asset-minifier "0.2.6"]])))
 
 (c/deftask minify
   "Minifies .js and .css files based on their file extension

--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -236,7 +236,7 @@
    NOTE: potentially slow when called with watch or multiple times"
   [i in  INPUT  str "Path to file to be compressed"
    o out OUTPUT str "Path to where compressed file should be saved"
-   l lang LANGUAGE_IN kw "Language of the input javascript file. Default value is ecmascript3."]
+   l lang LANGUAGE_IN kw "Language of the input javascript file. Default value is ecmascript6 in and ecmascript5 out."]
   (assert in "Path to input file required")
   (assert out "Path to output file required")
   (let [tmp      (c/tmp-dir!)

--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -254,7 +254,8 @@
           (pod/with-eval-in min-pod
             (require 'asset-minifier.core)
             (asset-minifier.core/minify-js ~in-path ~out-path (if ~lang
-                                                                {:language ~lang}
+                                                                {:language-in ~lang
+                                                                 :language-out ~lang}
                                                                 {})))
           (. in-path (endsWith "css"))
           (pod/with-eval-in min-pod


### PR DESCRIPTION
This PR changes the interface a bit but solves #53.

Generally, it should be backward compatible, as in updates to packages are only needed in `minify` opts.

`:lang -> :lang-in`

The ES6 input should be still OK for all packages.

Notes, objections?