### PR TITLE
Include explicit dependencies on javax.xml.bind for OpenJDK 11.

### DIFF
--- a/build.boot
+++ b/build.boot
@@ -4,6 +4,9 @@
                   [clj-http "3.7.0" :scope "test"]
                   [org.clojure/clojurescript "1.9.946" :scope "test"]
                   [cljsjs/react-dom "16.1.0-0" :scope "test"]
+                  [javax.xml.bind/jaxb-api "2.3.1"]
+                  [com.sun.xml.bind/jaxb-core "2.3.0.1"]
+                  [com.sun.xml.bind/jaxb-impl "2.3.2"]
                   ;; Conflicts with cljs
                   #_[asset-minifier "0.2.6" :scope "test" :exclusions []]])
 


### PR DESCRIPTION
These Java EE APIs were removed in JDK 11, so we need to explicitly depend on the jaxb libs.

I got this solution from here: 

https://stackoverflow.com/questions/43574426/how-to-resolve-java-lang-noclassdeffounderror-javax-xml-bind-jaxbexception-in-j

and here:

https://crunchify.com/java-11-and-javax-xml-bind-jaxbcontext/