### PR TITLE
Close zipfile before removing

### DIFF
--- a/src/cljsjs/boot_cljsjs/packaging.clj
+++ b/src/cljsjs/boot_cljsjs/packaging.clj
@@ -68,7 +68,8 @@
                   :let [target (io/file tmp (.getName entry))]]
             (io/make-parents target)
             (with-open [is (.getInputStream zipfile entry) ]
-              (io/copy is target))))
+              (io/copy is target)))
+          (.close zipfile))
         (-> fileset (c/rm archives) (c/add-resource tmp) c/commit!)))))
 
 (def decompress-deps '[[org.apache.commons/commons-compress "1.14"]])


### PR DESCRIPTION
Hi,

could you please consider the following patch to close zipfile before removing it, while unzipping.

It appears as if windows 7/10 is holding a handle to the open zip file, and as such can't remove it before is being closed.

For example, when building plotly from cljsjs/packages on windows (either 7 or 10), the following error is thrown:

.../cljsjs-packages/plotly $ boot package
...
Downloading v1.45.3.zip
...
Extracting 2873 files
                              java.lang.Thread.run                     
java.util.concurrent.ThreadPoolExecutor$Worker.run                     
 java.util.concurrent.ThreadPoolExecutor.runWorker                     
               java.util.concurrent.FutureTask.run                     
                                               ...                     
               clojure.core/binding-conveyor-fn/fn       core.clj: 1938
                                 boot.core/boot/fn       core.clj: 1031
                               boot.core/run-tasks       core.clj: 1022
     cljsjs.boot-cljsjs.packaging/eval3200/fn/G/fn  packaging.clj:  106
    cljsjs.boot-cljsjs.packaging/eval3088/fn/fn/fn  packaging.clj:   72
                                 boot.core/commit!       core.clj:  463
                    boot.tmpdir.TmpFileSet/commit!     tmpdir.clj:  258
                             boot.file/delete-file       file.clj:   71
                                               ...                     
                       clojure.java.io/delete-file         io.clj:  430
                       clojure.java.io/delete-file         io.clj:  434
java.io.IOException: Couldn't delete C:\Users\chaos\.boot\cache\tmp\dev\gh\cljsjs-packages\plotly\gps\-qix298\v1.45.3.zip

Thanks